### PR TITLE
Fixed links in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Learn Arduino
 
-- [Preparation](./00-installation)
-- [Coding Basics](./01-arduino-coding)
-- [Arduino Exercises](./02-arduino-exercises)
-- [Building RC Boat](./03-rc-boat)
+- [Preparation](./00-installation.md)
+- [Coding Basics](./01-arduino-coding.md)
+- [Arduino Exercises](./02-arduino-exercises.md)
+- [Building RC Boat](./03-rc-boat.md)


### PR DESCRIPTION
The links were not working due to missing .md in link URL, leading to
404 error. Thanks for the tutorial anyways!